### PR TITLE
Update OpenOCD configuration

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -8,6 +8,7 @@
 # runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 # runner = "gdb-multiarch -q -x openocd.gdb"
 # runner = "gdb -q -x openocd.gdb"
+runner = "arm-none-eabi-gdb -q -tui -x openocd.gdb"
 
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,5 +1,13 @@
 source [find interface/stlink-v2.cfg]
-source [find target/stm32l0_dual_bank.cfg]
+source [find target/stm32l0.cfg]
+
+# Add the second flash bank.
+#
+# This has been taken from `target/stm32l0_dual_bank.cfg` in OpenOCDs Git
+# repository. As of this writing, the latest release (0.10.0) doesn't include
+# that file yet.
+set _FLASHNAME $_CHIPNAME.flash1
+flash bank $_FLASHNAME stm32lx 0 0 0 0 $_TARGETNAME
 
 init
 reset halt

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink-v2-1.cfg]
 source [find target/stm32l0.cfg]
 
 # Add the second flash bank.

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,4 +1,5 @@
 source [find interface/stlink-v2-1.cfg]
+transport select hla_swd
 source [find target/stm32l0.cfg]
 
 # Add the second flash bank.


### PR DESCRIPTION
The configuration in the repository didn't work for me as-is using the STM32 LoRa and Sigfox Discovery kit. It does work for me with these changes, although somewhat unreliably.

@lthiery: Your last commit that touched `openocd.cfg` indicates that the configuration works for you, so I'm not sure if I'm breaking anything here. You also mentioned flashing J-Link firmware, so none of this might apply at all to you use case. All I can say is, this allowed me to flash an example to the stock Discovery board, while the old configuration didn't work for me at all.

Let me know what you think.